### PR TITLE
Adds regex special character removal to detail sheet names

### DIFF
--- a/openvas_to_report/libs/exporters/excel.py
+++ b/openvas_to_report/libs/exporters/excel.py
@@ -32,6 +32,7 @@ __all__ = ["export_to_excel"]
 
 from collections import Counter
 
+import re
 import xlsxwriter
 
 from ..data.parsed_data import Vulnerability
@@ -229,7 +230,9 @@ def _export_generic_format(output_file_name, vuln_info, lang):
             name = vuln.name
         else:
             name = "%s %s" % (trans["vulnerability"], vuln.id)
-        w1 = workbook.add_worksheet(name)
+
+		name = re.sub(r"[\[\]\:\*\?\/\\]", "", name)
+		w1 = workbook.add_worksheet(name)
 
         # --------------------------------------------------------------------------
         # Columns formats

--- a/openvas_to_report/libs/exporters/excel.py
+++ b/openvas_to_report/libs/exporters/excel.py
@@ -231,8 +231,8 @@ def _export_generic_format(output_file_name, vuln_info, lang):
         else:
             name = "%s %s" % (trans["vulnerability"], vuln.id)
 
-		name = re.sub(r"[\[\]\:\*\?\/\\]", "", name)
-		w1 = workbook.add_worksheet(name)
+        name = re.sub(r"[\[\]\:\*\?\/\\]", "", name)
+        w1 = workbook.add_worksheet(name)
 
         # --------------------------------------------------------------------------
         # Columns formats


### PR DESCRIPTION
Atomic fix to remove special characters that Excel doesn't like from worksheet names.
resolves #8 which was identified with an OpenVAS-9 XML report but this shouldn't break compatibility with prior versions of the report.