### PR TITLE
Change setting default parameters to something that will actually work

### DIFF
--- a/openvas_to_report/libs/data/parsed_data.py
+++ b/openvas_to_report/libs/data/parsed_data.py
@@ -197,12 +197,12 @@ class Vulnerability(object):
         :raises: TypeError, ValueError
         """
         # Get info
-        cves = kwargs.get("cves", [])
-        cvss = kwargs.get("cvss", -1.0)
-        description = kwargs.get("description", "")
-        references = kwargs.get("references", [])
-        level = kwargs.get("level", "low")
-        family = kwargs.get("family", "unknown")
+        cves = kwargs.get("cves") or []
+        cvss = kwargs.get("cvss") or -1.0
+        description = kwargs.get("description") or ""
+        references = kwargs.get("references") or []
+        level = kwargs.get("level") or "low"
+        family = kwargs.get("family") or "unknown"
 
         if not isinstance(id, str):
             raise TypeError("Expected basestring, got '%s' instead" % type(id))


### PR DESCRIPTION
`kwargs.get()` will only use a default parameter if the key is not found, not if it's `None`. In this case, every parameter is being given to the function so we'd actually have to check for the return value of `kwargs.get()` and then set the default.